### PR TITLE
Configurable basemap

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -9,6 +9,8 @@ if (!argv.mbtiles) {
     process.exit(1);
 }
 
+argv.basemap = argv.basemap || argv.base || argv.map || 'dark';
+
 function usage () {
     var text = [];
     text.push('usage: node cli.js [options]');
@@ -17,7 +19,7 @@ function usage () {
     text.push(' --port sets port to use');
     text.push(' --quiet or -q supress all logging except the address to visit');
     text.push(' -n don\'t automatically open the browser on start');
-    text.push(' --basemap sets a different basemap style (default: dark)');
+    text.push(' --basemap or --base or --map sets the basemap style (default: dark)');
     text.push(' --help prints this message');
     text.push('');
     return text.join('\n');
@@ -32,7 +34,7 @@ var params = {
     sourceId: 'default',
     zoom: 12,
     quiet: argv.q || argv.quiet
-    basemap: argv.basemap || 'dark'
+    basemap: argv.basemap
 };
 
 MBView.serve(params, function (err, config) {

--- a/cli.js
+++ b/cli.js
@@ -17,6 +17,7 @@ function usage () {
     text.push(' --port sets port to use');
     text.push(' --quiet or -q supress all logging except the address to visit');
     text.push(' -n don\'t automatically open the browser on start');
+    text.push(' --basemap sets a different basemap style (default: dark)');
     text.push(' --help prints this message');
     text.push('');
     return text.join('\n');
@@ -31,6 +32,7 @@ var params = {
     sourceId: 'default',
     zoom: 12,
     quiet: argv.q || argv.quiet
+    basemap: argv.basemap || 'dark'
 };
 
 MBView.serve(params, function (err, config) {

--- a/views/map.ejs
+++ b/views/map.ejs
@@ -18,7 +18,7 @@
 mapboxgl.accessToken = 'pk.eyJ1Ijoicm9kb3dpIiwiYSI6ImdZdDkyQU0ifQ.bPu86kwHgaenPhYp84g1yg';
 var map = new mapboxgl.Map({
     container: 'map',
-    style: 'mapbox://styles/mapbox/dark-v8',
+    style: 'mapbox://styles/mapbox/<%= basemap %>-v8',
     center: [<%= center %>],
     zoom: <%= zoom %>,
     hash: true,


### PR DESCRIPTION
@rodowi - For your consideration.

<img width="512" alt="screen shot 2016-05-06 at 11 44 16 pm" src="https://cloud.githubusercontent.com/assets/58878/15090677/7a02d79e-13e4-11e6-8cb1-85f45acde6eb.png">

- Allows for selecting a different mapbox style for the basemap

Current options include:
- dark (default)
- light
- satellite
- streets
- emerald
- bright
- empty
- basic

References #14