### PR TITLE
Refactor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,25 +1,25 @@
 module.exports = {
-    "env": {
-        "browser": true,
-        "node": true
-    },
-    "extends": "eslint:recommended",
-    "rules": {
-        "indent": [
-            "error",
-            4
-        ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "quotes": [
-            "error",
-            "single"
-        ],
-        "semi": [
-            "error",
-            "always"
-        ]
-    }
+  "env": {
+    "browser": true,
+    "node": true
+  },
+  "extends": "eslint:recommended",
+  "rules": {
+    "indent": [
+      "error",
+      2
+    ],
+    "linebreak-style": [
+      "error",
+      "unix"
+    ],
+    "quotes": [
+      "error",
+      "single"
+    ],
+    "semi": [
+      "error",
+      "always"
+    ]
+  }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,25 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "node": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "indent": [
+            "error",
+            4
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ]
+    }
+};

--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+/* eslint-disable no-console */
+
 var argv = require('minimist')(process.argv.slice(2));
 var open = require('open');
 var fs = require('fs');
@@ -16,7 +18,7 @@ if (argv.version || argv.v) {
 }
 
 try {
-    mbtiles.forEach(function (f) { fs.statSync(f).isFile() });
+    mbtiles.forEach(function (f) { fs.statSync(f).isFile(); });
 } catch(e) {
     return console.error(e);
 }

--- a/cli.js
+++ b/cli.js
@@ -10,17 +10,17 @@ var utils = require('./utils');
 var mbtiles = argv._;
 
 if (argv.version || argv.v) {
-    console.log(utils.version());
-    process.exit(0);
+  console.log(utils.version());
+  process.exit(0);
 } else if (!mbtiles.length) {
-    console.log(utils.usage());
-    process.exit(1);
+  console.log(utils.usage());
+  process.exit(1);
 }
 
 try {
-    mbtiles.forEach(function (f) { fs.statSync(f).isFile(); });
+  mbtiles.forEach(function (f) { fs.statSync(f).isFile(); });
 } catch(e) {
-    return console.error(e);
+  return console.error(e);
 }
 
 argv.basemap = argv.basemap || argv.base || argv.map || 'dark';
@@ -29,15 +29,15 @@ argv.basemap = argv.basemap || argv.base || argv.map || 'dark';
 var MBView = require('./mbview');
 
 var params = {
-    center: argv.center || [-122.42, 37.75],
-    mbtiles: mbtiles,
-    port: argv.port || 3000,
-    zoom: 12,
-    quiet: argv.q || argv.quiet,
-    basemap: argv.basemap
+  center: argv.center || [-122.42, 37.75],
+  mbtiles: mbtiles,
+  port: argv.port || 3000,
+  zoom: 12,
+  quiet: argv.q || argv.quiet,
+  basemap: argv.basemap
 };
 
 MBView.serve(params, function (err, config) {
-    console.log('Listening on http://localhost:' + config.port);
-    if (!argv.n) open('http://localhost:' + config.port);
+  console.log('Listening on http://localhost:' + config.port);
+  if (!argv.n) open('http://localhost:' + config.port);
 });

--- a/mbview.js
+++ b/mbview.js
@@ -4,7 +4,7 @@ var MBTiles = require('mbtiles');
 var path = require('path');
 var q = require('d3-queue').queue();
 var utils = require('./utils');
-const objectAssign = require('object-assign');
+var objectAssign = require('object-assign');
 
 app.set('views', __dirname + '/views');
 app.set('view engine', 'ejs');

--- a/mbview.js
+++ b/mbview.js
@@ -1,7 +1,8 @@
+/* eslint-disable no-console */
+
 var express = require('express');
 var app = express();
 var MBTiles = require('mbtiles');
-var path = require('path');
 var q = require('d3-queue').queue();
 var utils = require('./utils');
 var objectAssign = require('object-assign');
@@ -52,7 +53,7 @@ module.exports = {
             if (!config.quiet) console.log('*** Config', config);
 
             var finalConfig = configs.reduce(function (prev, curr) {
-              return utils.mergeConfigurations(prev, curr);
+                return utils.mergeConfigurations(prev, curr);
             }, {});
 
             listen(finalConfig, callback);

--- a/mbview.js
+++ b/mbview.js
@@ -15,73 +15,73 @@ var tilesets = {};
 
 module.exports = {
 
-    loadTiles: function (file, config, callback) {
-        new MBTiles(file, function(err, tiles) {
-            if (err) throw err;
-            tiles.getInfo(function (err, data) {
-                if (err) throw err;
-                if (!config.quiet) {
-                    console.log('*** Metadata found in the MBTiles');
-                    console.log(data);
-                }
-                // Save reference to tiles
-                tilesets[data.name] = tiles;
-                // Extends the configuration object with new parameters found
-                config = objectAssign({}, config, utils.metadata(data));
-                // d3-queue.defer pattern to return the result of the task
-                callback(null, config);
-            });
-        });
-    },
+  loadTiles: function (file, config, callback) {
+    new MBTiles(file, function(err, tiles) {
+      if (err) throw err;
+      tiles.getInfo(function (err, data) {
+        if (err) throw err;
+        if (!config.quiet) {
+          console.log('*** Metadata found in the MBTiles');
+          console.log(data);
+        }
+        // Save reference to tiles
+        tilesets[data.name] = tiles;
+        // Extends the configuration object with new parameters found
+        config = objectAssign({}, config, utils.metadata(data));
+        // d3-queue.defer pattern to return the result of the task
+        callback(null, config);
+      });
+    });
+  },
 
-    /**
-     * Defer loading of multiple MBTiles and spin up server.
-     * Will conflate configurations found in the sources.
-     * @param {Object} basic configuration, e.g. port
-     * @param {Function} a callback with the server configuration loaded
-     */
-    serve: function (config, callback) {
-        var loadTiles = this.loadTiles;
-        var listen = this.listen;
+  /**
+  * Defer loading of multiple MBTiles and spin up server.
+  * Will conflate configurations found in the sources.
+  * @param {Object} basic configuration, e.g. port
+  * @param {Function} a callback with the server configuration loaded
+  */
+  serve: function (config, callback) {
+    var loadTiles = this.loadTiles;
+    var listen = this.listen;
 
-        config.mbtiles.forEach(function (file) {
-            if (!config.quiet) console.log('*** Reading from', file);
-            q.defer(loadTiles, file, config);
-        });
-        q.awaitAll(function (error, configs) {
-            if (error) throw error;
-            if (!config.quiet) console.log('*** Config', config);
+    config.mbtiles.forEach(function (file) {
+      if (!config.quiet) console.log('*** Reading from', file);
+      q.defer(loadTiles, file, config);
+    });
+    q.awaitAll(function (error, configs) {
+      if (error) throw error;
+      if (!config.quiet) console.log('*** Config', config);
 
-            var finalConfig = configs.reduce(function (prev, curr) {
-                return utils.mergeConfigurations(prev, curr);
-            }, {});
+      var finalConfig = configs.reduce(function (prev, curr) {
+        return utils.mergeConfigurations(prev, curr);
+      }, {});
 
-            listen(finalConfig, callback);
-        });
-    },
+      listen(finalConfig, callback);
+    });
+  },
 
-    listen: function (config, onListen) {
-        app.get('/', function (req, res) {
-            res.render('map', config);
-        });
+  listen: function (config, onListen) {
+    app.get('/', function (req, res) {
+      res.render('map', config);
+    });
 
-        app.get('/:source/:z/:x/:y.pbf', function (req, res) {
-            var p = req.params;
-            if (!config.quiet) console.log('Serving', p.z + '/' + p.x + '/' + p.y);
+    app.get('/:source/:z/:x/:y.pbf', function (req, res) {
+      var p = req.params;
+      if (!config.quiet) console.log('Serving', p.z + '/' + p.x + '/' + p.y);
 
-            tilesets[p.source].getTile(p.z, p.x, p.y, function (err, tile, headers) {
-                if (err) {
-                    res.end();
-                } else {
-                    if (!config.quiet) console.log(headers);
-                    res.writeHead(200, headers);
-                    res.end(tile);
-                }
-            });
-        });
+      tilesets[p.source].getTile(p.z, p.x, p.y, function (err, tile, headers) {
+        if (err) {
+          res.end();
+        } else {
+          if (!config.quiet) console.log(headers);
+          res.writeHead(200, headers);
+          res.end(tile);
+        }
+      });
+    });
 
-        config.server = app.listen(config.port, function () {
-            onListen(null, config);
-        });
-    }
+    config.server = app.listen(config.port, function () {
+      onListen(null, config);
+    });
+  }
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "Rodolfo Wilhelmy <rwilhelmy@gmail.com> (http://wilhel.me)",
   "license": "MIT",
   "devDependencies": {
+    "eslint": "^2.13.1",
     "supertest": "^1.2.0",
     "tape": "^4.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   },
   "main": "server.js",
   "scripts": {
+    "lint": "eslint *.js test/",
+    "pretest": "npm run lint",
     "test": "tape test/*.test.js",
     "start": "node cli.js"
   },

--- a/test/mbview.test.js
+++ b/test/mbview.test.js
@@ -20,7 +20,7 @@ test('MBView.loadTiles', function (t) {
 });
 
 test('MBView.serve', function (t) {
-  t.plan(5);
+  t.plan(6);
 
   var params = {
     basemap: 'dark',
@@ -43,6 +43,8 @@ test('MBView.serve', function (t) {
         t.true(match, 'loads a map with lines from first tileset');
         match = res.text.match(/hospitals-pts/)[0];
         t.true(match, 'loads a map with points from second tileset');
+        match = res.text.match(/menu-container/)[0];
+        t.true(match, 'should have a menu');
       });
 
     request('localhost:9000')

--- a/test/mbview.test.js
+++ b/test/mbview.test.js
@@ -50,14 +50,14 @@ test('MBView.serve', function (t) {
     request('localhost:9000')
       .get('/#14/32.5376/-117.0374')
       .expect('Content-Type', 'text/html; charset=utf-8')
-      .end(function (err, res) {
+      .end(function (err) {
         t.error(err, 'responds to Mapbox GL JS panning');
       });
 
     request('localhost:9000')
       .get('/baja-highways.mbtiles/14/2864/6624.pbf')
       .expect('Content-Type', 'application/x-protobuf')
-      .end(function (err, res) {
+      .end(function (err) {
         t.error(err, 'serves protobufs');
       });
   });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,9 +1,9 @@
 var test = require('tape').test;
 var fs = require('fs');
 var utils = require('../utils');
-const objectAssign = require('object-assign');
+var objectAssign = require('object-assign');
 
-const fixtures = {
+var fixtures = {
   metadata: JSON.parse(fs.readFileSync(__dirname + '/fixtures/metadata.json'))
 };
 

--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,5 @@
 var fs = require('fs');
-const objectAssign = require('object-assign');
+var objectAssign = require('object-assign');
 
 /**
  * Extract some metadata from MBTiles

--- a/views/layers.ejs
+++ b/views/layers.ejs
@@ -1,0 +1,30 @@
+
+map.addLayer({
+  'id': '<%= sources[sid].layers %>-lines',
+  'type': 'line',
+  'source': '<%= sid %>',
+  'source-layer': '<%= sources[sid].layers %>',
+  'layout': {
+    'line-join': 'round',
+    'line-cap': 'round'
+  },
+  'paint': {
+    'line-color': '#' + randomColor(lightColors),
+    'line-width': 1
+  }
+});
+
+map.addLayer({
+  'id': '<%= sources[sid].layers %>-pts',
+  'type': 'circle',
+  'source': '<%= sid %>',
+  'source-layer': '<%= sources[sid].layers %>',
+  'filter': ["==", "$type", "Point"],
+  'paint': {
+    'circle-color': '#' + randomColor(lightColors),
+    'circle-radius': 2
+  }
+});
+
+layers.lines.push('<%= sources[sid].layers %>-lines');
+layers.pts.push('<%= sources[sid].layers %>-pts');

--- a/views/map.ejs
+++ b/views/map.ejs
@@ -55,9 +55,7 @@ function randomColor(colors) {
 }
 
 map.on('load', function () {
-
   <% Object.keys(sources).forEach(function (sid) { %>
-
     map.addSource('<%= sid %>', {
       type: 'vector',
       tiles: [
@@ -66,37 +64,8 @@ map.on('load', function () {
       maxzoom: <%= maxzoom %>
     });
 
-    map.addLayer({
-      'id': '<%= sources[sid].layers %>-lines',
-      'type': 'line',
-      'source': '<%= sid %>',
-      'source-layer': '<%= sources[sid].layers %>',
-      'layout': {
-        'line-join': 'round',
-        'line-cap': 'round'
-      },
-      'paint': {
-        'line-color': '#' + randomColor(lightColors),
-        'line-width': 1
-      }
-    });
-    layers.lines.push('<%= sources[sid].layers %>-lines');
-
-    map.addLayer({
-      'id': '<%= sources[sid].layers %>-pts',
-      'type': 'circle',
-      'source': '<%= sid %>',
-      'source-layer': '<%= sources[sid].layers %>',
-      'filter': ["==", "$type", "Point"],
-      'paint': {
-        'circle-color': '#' + randomColor(lightColors),
-        'circle-radius': 2
-      }
-    });
-    layers.pts.push('<%= sources[sid].layers %>-pts');
-
+    <% include layers %>
   <% }); %>
-
 });
 
 </script>

--- a/views/map.ejs
+++ b/views/map.ejs
@@ -10,60 +10,15 @@
     <style>
         body { margin:0; padding:0; }
         #map { position:absolute; top:0; bottom:0; width:100%; }
-        #menu { position: absolute; top:10px; right:10px; z-index: 1; color: white; cursor: pointer; }
-        #menu-container { position: absolute; display: none; top: 50px; right: 10px; z-index: 1; background-color: white; padding: 20px; }
     </style>
 </head>
 <body>
 
-<div id="menu"><span class='icon menu big'></span></div>
-
-<div id="menu-container">
-    <h4>Filter</h4>
-    <div id="menu-filter" onchange="menuFilter()" class='rounded-toggle short inline'>
-      <input id='filter-all' type='radio' name='rtoggle' value='all' checked='checked'>
-      <label for='filter-all'>all</label>
-      <input id='filter-lines' type='radio' name='rtoggle' value='lines'>
-      <label for='filter-lines'>lines</label>
-      <input id='filter-pts' type='radio' name='rtoggle' value='pts'>
-      <label for='filter-pts'>points</label>
-    </div>
-</div>
+<% include menu %>
 
 <div id='map'></div>
 
 <script>
-//Show and hide hamburger menu as needed
-var menuBtn = document.querySelector("#menu");
-var menu = document.querySelector("#menu-container");
-menuBtn.addEventListener('click', function() {
-    if (menuBtn.className.indexOf('active') > -1) {
-        //Hide Menu
-        menuBtn.className = '';
-        menu.style.display = 'none';
-    } else {
-        //Show Menu
-        menuBtn.className = 'active';
-        menu.style.display = 'block';
-
-    }
-}, false);
-
-//Menu-Filter Module
-function menuFilter() {
-    if (document.querySelector("#filter-all").checked) {
-        paint(layers.pts, 'visible');
-        paint(layers.lines, 'visible');
-    } else if (document.querySelector("#filter-pts").checked) {
-        paint(layers.pts, 'visible');
-        paint(layers.lines, 'none');
-    } else if (document.querySelector("#filter-lines").checked) {
-        paint(layers.pts, 'none');
-        paint(layers.lines, 'visible');
-    }
-
-    function paint(layers, val) { layers.forEach(function(layer) { map.setLayoutProperty(layer, 'visibility', val) }); } 
-}
 
 mapboxgl.accessToken = 'pk.eyJ1Ijoicm9kb3dpIiwiYSI6ImdZdDkyQU0ifQ.bPu86kwHgaenPhYp84g1yg';
 var map = new mapboxgl.Map({

--- a/views/map.ejs
+++ b/views/map.ejs
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset='utf-8' />
-    <title></title>
-    <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.18.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.18.0/mapbox-gl.css' rel='stylesheet' />
-    <link href='https://www.mapbox.com/base/latest/base.css' rel='stylesheet' />
-    <style>
-        body { margin:0; padding:0; }
-        #map { position:absolute; top:0; bottom:0; width:100%; }
-    </style>
+  <meta charset='utf-8' />
+  <title></title>
+  <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.18.0/mapbox-gl.js'></script>
+  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.18.0/mapbox-gl.css' rel='stylesheet' />
+  <link href='https://www.mapbox.com/base/latest/base.css' rel='stylesheet' />
+  <style>
+    body { margin:0; padding:0; }
+    #map { position:absolute; top:0; bottom:0; width:100%; }
+  </style>
 </head>
 <body>
 
@@ -22,78 +22,80 @@
 
 mapboxgl.accessToken = 'pk.eyJ1Ijoicm9kb3dpIiwiYSI6ImdZdDkyQU0ifQ.bPu86kwHgaenPhYp84g1yg';
 var map = new mapboxgl.Map({
-    container: 'map',
-    style: 'mapbox://styles/mapbox/<%= basemap %>-v8',
-    center: [<%= center %>],
-    zoom: <%= zoom %>,
-    hash: true,
-    maxZoom: 30
+  container: 'map',
+  style: 'mapbox://styles/mapbox/<%= basemap %>-v8',
+  center: [<%= center %>],
+  zoom: <%= zoom %>,
+  hash: true,
+  maxZoom: 30
 });
 
 var layers = {
-    pts: [],
-    lines: []
+  pts: [],
+  lines: []
 }
 
 var lightColors = [
-    'FC49A3', // pink
-    'CC66FF', // purple-ish
-    '66CCFF', // sky blue
-    '66FFCC', // teal
-    '00FF00', // lime green
-    'FFCC66', // light orange
-    'FF6666', // salmon
-    'FF0000', // red
-    'FF8000', // orange
-    'FFFF66', // yellow
-    '00FFFF'  // turquoise
+  'FC49A3', // pink
+  'CC66FF', // purple-ish
+  '66CCFF', // sky blue
+  '66FFCC', // teal
+  '00FF00', // lime green
+  'FFCC66', // light orange
+  'FF6666', // salmon
+  'FF0000', // red
+  'FF8000', // orange
+  'FFFF66', // yellow
+  '00FFFF'  // turquoise
 ];
 
 function randomColor(colors) {
-    var randomNumber = parseInt(Math.random() * colors.length);
-    return colors[randomNumber];
+  var randomNumber = parseInt(Math.random() * colors.length);
+  return colors[randomNumber];
 }
 
 map.on('load', function () {
 
-    <% Object.keys(sources).forEach(function (sid) { %>
-        map.addSource('<%= sid %>', {
-            type: 'vector',
-            tiles: [
-                'http://localhost:<%= port %>/<%= sid %>/{z}/{x}/{y}.pbf'
-            ],
-            maxzoom: <%= maxzoom %>
-        });
-        map.addLayer({
-            'id': '<%= sources[sid].layers %>-lines',
-            'type': 'line',
-            'source': '<%= sid %>',
-            'source-layer': '<%= sources[sid].layers %>',
-            'layout': {
-                'line-join': 'round',
-                'line-cap': 'round'
-            },
-            'paint': {
-                'line-color': '#' + randomColor(lightColors),
-                'line-width': 1
-            }
-        });
-        layers.lines.push('<%= sources[sid].layers %>-lines');
+  <% Object.keys(sources).forEach(function (sid) { %>
 
-        map.addLayer({
-            'id': '<%= sources[sid].layers %>-pts',
-            'type': 'circle',
-            'source': '<%= sid %>',
-            'source-layer': '<%= sources[sid].layers %>',
-            'filter': ["==", "$type", "Point"],
-            'paint': {
-                'circle-color': '#' + randomColor(lightColors),
-                'circle-radius': 2
-            }
-        });
-        layers.pts.push('<%= sources[sid].layers %>-pts');
+    map.addSource('<%= sid %>', {
+      type: 'vector',
+      tiles: [
+        'http://localhost:<%= port %>/<%= sid %>/{z}/{x}/{y}.pbf'
+      ],
+      maxzoom: <%= maxzoom %>
+    });
 
-    <% }); %>
+    map.addLayer({
+      'id': '<%= sources[sid].layers %>-lines',
+      'type': 'line',
+      'source': '<%= sid %>',
+      'source-layer': '<%= sources[sid].layers %>',
+      'layout': {
+        'line-join': 'round',
+        'line-cap': 'round'
+      },
+      'paint': {
+        'line-color': '#' + randomColor(lightColors),
+        'line-width': 1
+      }
+    });
+    layers.lines.push('<%= sources[sid].layers %>-lines');
+
+    map.addLayer({
+      'id': '<%= sources[sid].layers %>-pts',
+      'type': 'circle',
+      'source': '<%= sid %>',
+      'source-layer': '<%= sources[sid].layers %>',
+      'filter': ["==", "$type", "Point"],
+      'paint': {
+        'circle-color': '#' + randomColor(lightColors),
+        'circle-radius': 2
+      }
+    });
+    layers.pts.push('<%= sources[sid].layers %>-pts');
+
+  <% }); %>
 
 });
 

--- a/views/menu.ejs
+++ b/views/menu.ejs
@@ -1,0 +1,54 @@
+<style>
+  #menu { position: absolute; top:10px; right:10px; z-index: 1; color: white; cursor: pointer; }
+  #menu-container { position: absolute; display: none; top: 50px; right: 10px; z-index: 1; background-color: white; padding: 20px; }
+</style>
+
+<div id="menu"><span class='icon menu big'></span></div>
+
+<div id="menu-container">
+    <h4>Filter</h4>
+    <div id="menu-filter" onchange="menuFilter()" class='rounded-toggle short inline'>
+      <input id='filter-all' type='radio' name='rtoggle' value='all' checked='checked'>
+      <label for='filter-all'>all</label>
+      <input id='filter-lines' type='radio' name='rtoggle' value='lines'>
+      <label for='filter-lines'>lines</label>
+      <input id='filter-pts' type='radio' name='rtoggle' value='pts'>
+      <label for='filter-pts'>points</label>
+    </div>
+</div>
+
+<script>
+
+//Show and hide hamburger menu as needed
+var menuBtn = document.querySelector("#menu");
+var menu = document.querySelector("#menu-container");
+menuBtn.addEventListener('click', function() {
+    if (menuBtn.className.indexOf('active') > -1) {
+        //Hide Menu
+        menuBtn.className = '';
+        menu.style.display = 'none';
+    } else {
+        //Show Menu
+        menuBtn.className = 'active';
+        menu.style.display = 'block';
+
+    }
+}, false);
+
+//Menu-Filter Module
+function menuFilter() {
+    if (document.querySelector("#filter-all").checked) {
+        paint(layers.pts, 'visible');
+        paint(layers.lines, 'visible');
+    } else if (document.querySelector("#filter-pts").checked) {
+        paint(layers.pts, 'visible');
+        paint(layers.lines, 'none');
+    } else if (document.querySelector("#filter-lines").checked) {
+        paint(layers.pts, 'none');
+        paint(layers.lines, 'visible');
+    }
+
+    function paint(layers, val) { layers.forEach(function(layer) { map.setLayoutProperty(layer, 'visibility', val) }); }
+}
+
+</script>

--- a/views/menu.ejs
+++ b/views/menu.ejs
@@ -1,6 +1,21 @@
 <style>
-  #menu { position: absolute; top:10px; right:10px; z-index: 1; color: white; cursor: pointer; }
-  #menu-container { position: absolute; display: none; top: 50px; right: 10px; z-index: 1; background-color: white; padding: 20px; }
+    #menu {
+        position: absolute;
+        top:10px;
+        right:10px;
+        z-index: 1;
+        color: white;
+        cursor: pointer;
+    }
+    #menu-container {
+        position: absolute;
+        display: none;
+        top: 50px;
+        right: 10px;
+        z-index: 1;
+        background-color: white;
+        padding: 20px;
+    }
 </style>
 
 <div id="menu"><span class='icon menu big'></span></div>
@@ -8,12 +23,12 @@
 <div id="menu-container">
     <h4>Filter</h4>
     <div id="menu-filter" onchange="menuFilter()" class='rounded-toggle short inline'>
-      <input id='filter-all' type='radio' name='rtoggle' value='all' checked='checked'>
-      <label for='filter-all'>all</label>
-      <input id='filter-lines' type='radio' name='rtoggle' value='lines'>
-      <label for='filter-lines'>lines</label>
-      <input id='filter-pts' type='radio' name='rtoggle' value='pts'>
-      <label for='filter-pts'>points</label>
+        <input id='filter-all' type='radio' name='rtoggle' value='all' checked='checked'>
+        <label for='filter-all'>all</label>
+        <input id='filter-lines' type='radio' name='rtoggle' value='lines'>
+        <label for='filter-lines'>lines</label>
+        <input id='filter-pts' type='radio' name='rtoggle' value='pts'>
+        <label for='filter-pts'>points</label>
     </div>
 </div>
 
@@ -48,7 +63,11 @@ function menuFilter() {
         paint(layers.lines, 'visible');
     }
 
-    function paint(layers, val) { layers.forEach(function(layer) { map.setLayoutProperty(layer, 'visibility', val) }); }
+    function paint(layers, val) {
+        layers.forEach(function(layer) {
+            map.setLayoutProperty(layer, 'visibility', val)
+        });
+    }
 }
 
 </script>

--- a/views/menu.ejs
+++ b/views/menu.ejs
@@ -1,73 +1,73 @@
 <style>
-    #menu {
-        position: absolute;
-        top:10px;
-        right:10px;
-        z-index: 1;
-        color: white;
-        cursor: pointer;
-    }
-    #menu-container {
-        position: absolute;
-        display: none;
-        top: 50px;
-        right: 10px;
-        z-index: 1;
-        background-color: white;
-        padding: 20px;
-    }
+#menu {
+  position: absolute;
+  top:10px;
+  right:10px;
+  z-index: 1;
+  color: white;
+  cursor: pointer;
+}
+#menu-container {
+  position: absolute;
+  display: none;
+  top: 50px;
+  right: 10px;
+  z-index: 1;
+  background-color: white;
+  padding: 20px;
+}
 </style>
 
 <div id="menu"><span class='icon menu big'></span></div>
 
 <div id="menu-container">
-    <h4>Filter</h4>
-    <div id="menu-filter" onchange="menuFilter()" class='rounded-toggle short inline'>
-        <input id='filter-all' type='radio' name='rtoggle' value='all' checked='checked'>
-        <label for='filter-all'>all</label>
-        <input id='filter-lines' type='radio' name='rtoggle' value='lines'>
-        <label for='filter-lines'>lines</label>
-        <input id='filter-pts' type='radio' name='rtoggle' value='pts'>
-        <label for='filter-pts'>points</label>
-    </div>
+  <h4>Filter</h4>
+  <div id="menu-filter" onchange="menuFilter()" class='rounded-toggle short inline'>
+    <input id='filter-all' type='radio' name='rtoggle' value='all' checked='checked'>
+    <label for='filter-all'>all</label>
+    <input id='filter-lines' type='radio' name='rtoggle' value='lines'>
+    <label for='filter-lines'>lines</label>
+    <input id='filter-pts' type='radio' name='rtoggle' value='pts'>
+    <label for='filter-pts'>points</label>
+  </div>
 </div>
 
 <script>
 
-//Show and hide hamburger menu as needed
+// Show and hide hamburger menu as needed
 var menuBtn = document.querySelector("#menu");
 var menu = document.querySelector("#menu-container");
 menuBtn.addEventListener('click', function() {
-    if (menuBtn.className.indexOf('active') > -1) {
-        //Hide Menu
-        menuBtn.className = '';
-        menu.style.display = 'none';
-    } else {
-        //Show Menu
-        menuBtn.className = 'active';
-        menu.style.display = 'block';
+  if (menuBtn.className.indexOf('active') > -1) {
+    //Hide Menu
+    menuBtn.className = '';
+    menu.style.display = 'none';
+  } else {
+    //Show Menu
+    menuBtn.className = 'active';
+    menu.style.display = 'block';
 
-    }
+  }
 }, false);
 
 //Menu-Filter Module
 function menuFilter() {
-    if (document.querySelector("#filter-all").checked) {
-        paint(layers.pts, 'visible');
-        paint(layers.lines, 'visible');
-    } else if (document.querySelector("#filter-pts").checked) {
-        paint(layers.pts, 'visible');
-        paint(layers.lines, 'none');
-    } else if (document.querySelector("#filter-lines").checked) {
-        paint(layers.pts, 'none');
-        paint(layers.lines, 'visible');
-    }
+  if (document.querySelector("#filter-all").checked) {
+    paint(layers.pts, 'visible');
+    paint(layers.lines, 'visible');
+  } else if (document.querySelector("#filter-pts").checked) {
+    paint(layers.pts, 'visible');
+    paint(layers.lines, 'none');
+  } else if (document.querySelector("#filter-lines").checked) {
+    paint(layers.pts, 'none');
+    paint(layers.lines, 'visible');
+  }
 
-    function paint(layers, val) {
-        layers.forEach(function(layer) {
-            map.setLayoutProperty(layer, 'visibility', val)
-        });
-    }
+  function paint(layers, val) {
+    layers.forEach(function(layer) {
+      map.setLayoutProperty(layer, 'visibility', val)
+    });
+  }
 }
 
 </script>


### PR DESCRIPTION
This PR cleans up the code a little bit. Expect the same behavior.

- [x] Add eslint to enforce a basic non-es6 style
- [x] Run eslint on `npm test`
- [x] Use templates to clean up the views

To new templates are added:
- `menu.ejs` where we can isolate new features related to the floating menu #3 #6 #39 
- `layers.ejs` where we can add logic for supporting multiple layers #3 

Closes #20 

cc: @aaronlidman 