### PR TITLE
Exit if access_token is missing

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -20,6 +20,9 @@ if (argv.version || argv.v) {
 } else if (!mbtiles.length) {
   console.log(utils.usage());
   process.exit(1);
+} else if (!accessToken) {
+  console.log('missing access token, try `export MAPBOX_ACCESS_TOKEN=...`');
+  process.exit(1);
 }
 
 try {


### PR DESCRIPTION
This PR checks for the accessToken var and exits if it's missing

closes https://github.com/mapbox/mbview/issues/68

```
➜  mbview git:(cli-complain) ✗ node cli.js examples/baja-highways.mbtiles 
missing access token, try `export MAPBOX_ACCESS_TOKEN=...`
```

cc: @lukasmartinelli