### PR TITLE
add 'Access-Control-Allow-Origin' = * header

### DIFF
--- a/mbview.js
+++ b/mbview.js
@@ -73,6 +73,7 @@ module.exports = {
         if (err) {
           res.end();
         } else {
+          headers['Access-Control-Allow-Origin'] = '*';
           res.writeHead(200, headers);
           res.end(tile);
         }


### PR DESCRIPTION
My workflow for developing tile sets involves creating a tileset with some tool(frequently tippecanoe), viewing with mbview for QA, then another QA step where it gets viewed in an existing style. Having mbview send an `Access-Control-Allow-Origin` header eliminates the the need to start another server to serve tiles for that final QA step.