### PR TITLE
use @mapbox scoped namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [3.0.0] - 2019-06-21
+- Breaking: move to @mapbox namespace
 - Breaking: remove support for Node 6
 - Upgrade dependencies
 - Linting updates

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mbview",
+  "name": "@mapbox/mbview",
   "version": "3.0.0",
   "description": "Watch mbtiles in your localhost",
   "bin": {


### PR DESCRIPTION
Quick follow-up to #91 to move this package to the `@mapbox` scoped namespace on npm.

cc @tcql 