### PR TITLE
remove static public path

### DIFF
--- a/mbview.js
+++ b/mbview.js
@@ -10,7 +10,6 @@ const objectAssign = require('object-assign');
 
 app.set('views', __dirname + '/views');
 app.set('view engine', 'ejs');
-app.use(express.static('public'));
 
 module.exports = {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mbview",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
with the static `public` path being set, I'm not seeing only seeing a minimal HTML page loaded without any content, I needed to remove that line to get it working. Not sure what changed recently or if this only seems to affect me, but this is with a clean node_modules installed and running exactly the master branch.