### PR TITLE
Choose a random port instead of always using 3000 by default

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -40,7 +40,7 @@ const MBView = require('./mbview');
 const params = {
   center: argv.center || [-122.42, 37.75],
   mbtiles: mbtiles,
-  port: argv.port || 3000,
+  port: argv.port || 3000 + Math.floor(Math.random() * 50000),
   zoom: 12,
   quiet: argv.q || argv.quiet,
   basemap: argv.basemap,


### PR DESCRIPTION
So that it is easy to have multiple instances of mbview running at the same time without having to set the port manually